### PR TITLE
Introducting send TCP timeout and fix panic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+statsrelay (0.0.4) unstable; urgency=medium
+
+  * Build with Go 1.7.3
+  * Add TCP send proto timeout support and connection refused handling
+
+ -- Slawomir Skowron <sziszibis@gmail.com>  Wed, 30 Nov 2016 17:39:13 +0200
+
 statsrelay (0.0.2) unstable; urgency=medium
 
   * Build with Go 1.5

--- a/statsrelay.go
+++ b/statsrelay.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-const VERSION string = "0.0.3"
+const VERSION string = "0.0.4"
 
 // BUFFERSIZE controls the size of the [...]byte array used to read UDP data
 // off the wire and into local memory.  Metrics are separated by \n


### PR DESCRIPTION
* Fix panic when domain in hash is no accessible (connection refused):
```
2016/11/29 23:48:24 Starting version 0.0.3
2016/11/29 23:48:24 Listening on 0.0.0.0:8125
2016/11/29 23:48:24 Setting socket read buffer size to: 131071
2016/11/29 23:48:24 Rock and Roll!
2016/11/29 23:48:46 Sending deploy.test.myservice to stats1.example.com:8125
2016/11/29 23:48:46 TCP timeout dial tcp 9.9.9.9:8125: i/o timeout
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x402702]

goroutine 16 [running]:
panic(0x570440, 0xc8200100d0)
	/usr/local/Cellar/go/1.6.3/libexec/src/runtime/panic.go:481 +0x3e6
main.sendPacket(0xc820046094, 0x1b, 0x40, 0x7ffd02774d0a, 0x36, 0x7ffd02774c94, 0x3)
	/Users/slawomirskowron/github/statsrelay/statsrelay.go:115 +0x422
main.handleBuff(0xc8200da000, 0x1c, 0x100000)
	/Users/slawomirskowron/github/statsrelay/statsrelay.go:229 +0x823
created by main.runServer
	/Users/slawomirskowron/github/statsrelay/statsrelay.go:323 +0x2f3
```
* Fix handling of this timeout and adding new arg for setting timeout when TCP send protocol is set.
```
2016/11/30 15:49:04 Starting version 0.0.3
2016/11/30 15:49:04 Listening on 0.0.0.0:8125
2016/11/30 15:49:04 Setting socket read buffer size to: 131071
2016/11/30 15:49:04 TCP send timeout 5s
2016/11/30 15:49:04 Rock and Roll!
2016/11/30 15:49:08 Sending deploy.test.myservice to stats1.example.com:8125
2016/11/30 15:49:13 TCP timeout for 9.9.9.9:8125 - dial tcp 9.9.9.9:8125: i/o timeout
2016/11/30 15:49:18 TCP timeout for 90.90.90.90:8125 - dial tcp 90.90.90.90:8125: i/o timeout
2016/11/30 15:49:18 Procssed 1 metrics. Running total: 1. Metrics/sec: 0
```
No panic and custom timeout in this example after 5 second and default is set to 1 second.

* Bump version in debian changelog and code. 
* Building debian package with go 1.7.3 and it works 😄 . Field testing soon.