### PR TITLE
Add metrics prefix feature - k8s usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,17 @@ Command synopsis:
     -p=9125: Port to listen on
     -port=9125: Port to listen on
     -prefix="statsrelay": The prefix to use with self generated stats
-
+    -metrics-prefix="production.us-east-1": The prefix to use with metrics passed through statsrelay
+    -bufsize="32768": Read buffer size
+    -packetlen="1400": Max packet length. Must be lower than MTU plus IPv4 and UDP headers to avoid fragmentation.
+    -sendproto="TCP": IP Protocol for sending data - TCP or UDP
+    -tcptimeout="500ms": Timeout for TCP client remote connections
+    -verbose=true: Verbose output
 
 You must specify at least one HOST:PORT combination.  The INSTANCE can be
 used to further populate or weight the consistent hashing ring as you see fit.
 The instance is stripped before using the HOST and PORT to create a UDP
-socket.
+socket or TCP connection.
 
 Algorithms and Performance
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Command synopsis:
     -p=9125: Port to listen on
     -port=9125: Port to listen on
     -prefix="statsrelay": The prefix to use with self generated stats
-    -metrics-prefix="production.us-east-1": The prefix to use with metrics passed through statsrelay
+    -metrics-prefix="": The prefix to use with metrics passed through statsrelay
     -bufsize="32768": Read buffer size
     -packetlen="1400": Max packet length. Must be lower than MTU plus IPv4 and UDP headers to avoid fragmentation.
-    -sendproto="TCP": IP Protocol for sending data - TCP or UDP
-    -tcptimeout="500ms": Timeout for TCP client remote connections
-    -verbose=true: Verbose output
+    -sendproto="UDP": IP Protocol for sending data - TCP or UDP
+    -tcptimeout="1s": Timeout for TCP client remote connections
+    -verbose=false: Verbose output
 
 You must specify at least one HOST:PORT combination.  The INSTANCE can be
 used to further populate or weight the consistent hashing ring as you see fit.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,15 @@
+statsrelay (0.0.5) unstable; urgency=medium
+
+  * Add forwarded metrics prefix
+
+ -- Slawomir Skowron <slawomir.skowron@gmail.com>  Mon, 12 Dec 2016 22:05:13 +0100
+
 statsrelay (0.0.4) unstable; urgency=medium
 
   * Build with Go 1.7.3
   * Add TCP send proto timeout support and connection refused handling
 
- -- Slawomir Skowron <sziszibis@gmail.com>  Wed, 30 Nov 2016 17:39:13 +0200
+ -- Slawomir Skowron <slawomir.skowron@gmail.com>  Wed, 30 Nov 2016 17:39:13 +0200
 
 statsrelay (0.0.2) unstable; urgency=medium
 

--- a/statsrelay.go
+++ b/statsrelay.go
@@ -95,17 +95,14 @@ func getSockBufferMaxSize() (int, error) {
 func getMetricName(metric []byte) (string, error) {
 	// statsd metrics are of the form:
 	//    KEY:VALUE|TYPE|RATE or KEY:VALUE|TYPE|RATE|#tags
-	var metricName string
 	length := bytes.IndexByte(metric, byte(':'))
 	if length == -1 {
 		return "error", errors.New("Length of -1, must be invalid StatsD data")
 	}
 	if len(metricsPrefix) != 0 {
 		return genPrefix(metric[:length], metricsPrefix), nil
-	} else {
-		metricName = string(metric[:length])
 	}
-	return metricName, nil
+	return string(metric[:length]), nil
 }
 
 func genPrefix(metric []byte, metricsPrefix string) string {
@@ -224,6 +221,7 @@ func handleBuff(buff []byte) {
 				buffPrefix, err := addPrefix(buff[offset:offset+size], metricsPrefix)
 				if err != nil {
 					log.Printf("Error %s when adding prefix %s", err, metricsPrefix)
+					break
 				}
 				packets[target].Write(buffPrefix)
 			} else {


### PR DESCRIPTION
We need to add static prefix to all metrics in k8s POD context.

Each application deploy have own statsrelay inside local POD and send data over 127.0.0.1:8125 UDP to statsrelay which sending data over TCP to centralised statsite cluster.

Metrics prefix works like statsrelay internal stats prefix but it is added to each metric passed through statsrelay to statsite. 

Each private ELB behind Route53 internal domain with DNS failover to other domain and all with health-checks. Each statsite + internal ELB inside ASG with one statsite instance replaced to new if failed. This setup is HA and guarantee that metrics from statsrelay's will always go to same statsite instance.

<img width="1200" alt="screen shot 2016-12-12 at 22 17 13" src="https://cloud.githubusercontent.com/assets/329831/21117176/ea1286d4-c0b8-11e6-8e38-cb6a1bddae44.png">

With this feature we can add environment, k8s cluster id, region, and app name from k8s context with deployed application to metric key name.
Every app reports metrics without any prefix configured inside app code and always land with proper name inside graphite.
This is need when we like to deploy lot of app's and systems inside PaaS like k8s and using docker (configured through ENV variables).