### PR TITLE
Add tags support in relayed metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Command synopsis:
     -port=9125: Port to listen on
     -prefix="statsrelay": The prefix to use with self generated stats
     -metrics-prefix="": The prefix to use with metrics passed through statsrelay
+    -metrics-tags="": Metrics tags added at the end of each relayed metric
     -bufsize="32768": Read buffer size
     -packetlen="1400": Max packet length. Must be lower than MTU plus IPv4 and UDP headers to avoid fragmentation.
     -sendproto="UDP": IP Protocol for sending data - TCP or UDP

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+statsrelay (0.0.6) unstable; urgency=medium
+
+  * Add tags support in relayed metrics
+
+ -- Slawomir Skowron <slawomir.skowron@gmail.com>  Mon, 25 Dec 2016 14:05:13 +0100
+
 statsrelay (0.0.5) unstable; urgency=medium
 
   * Add forwarded metrics prefix

--- a/statsrelay.go
+++ b/statsrelay.go
@@ -115,7 +115,7 @@ func getMetricName(metric []byte) (string, error) {
 // genPrefix() combine metric []byte with metricsPrefix string and return as string
 func genPrefix(metric []byte, metricsPrefix string) string {
 	if len(metricsPrefix) != 0 {
-		return metricsPrefix + "." + string(metric)
+		return fmt.Sprintf("%s.%s", metricsPrefix, string(metric))
 	}
 	return string(metric)
 }
@@ -142,9 +142,9 @@ func genTags(metric, metricTags string) string {
 	// KEY:VALUE|TYPE|RATE or KEY:VALUE|TYPE|RATE|#tags
 	// This function add or extend #tags in metric
 	if strings.Contains((metric), "|#") {
-		return metric + "," + metricTags
+		return fmt.Sprintf("%s,%s", metric, metricTags)
 	}
-	return metric + "|#" + metricTags
+	return fmt.Sprintf("%s|#%s", metric, metricTags)
 }
 
 // sendPacket takes a []byte and writes that directly to a UDP socket
@@ -169,7 +169,7 @@ func sendPacket(buff []byte, target string, sendproto string, TCPtimeout time.Du
 			break
 		}
 		conn.Write(buff)
-		conn.Close()
+		defer conn.Close()
 	case "TEST":
 		// A test no-op
 	default:


### PR DESCRIPTION
This PR adds support for statsd metrics tags supported by Datadog - https://help.datadoghq.com/hc/en-us/articles/204312749-Getting-started-with-tags

Adds new option metrics-tags which is used to add tags at the end of each metric just like prefix on the beginning.
Sending metic with tags:
```
echo "test.service.counter:1|c|@1.000000|#foo:bar,test" | nc -w 1 -u 127.0.0.1 9125
```
and statsrelay running with example:
```
statsrelay -sendproto=TCP -b=127.0.0.1 -metrics-prefix=prefix -metrics-tags=relaytag,relay:tag 10.1.1.1:8125
```
This will produce:
```
prefix.test.service.counter:1|c|@1.000000|#foo:bar,test,relaytag,relay:tag
statsrelay.statsProcessed:1|c
```
If no tag in metric and defined in statsrelay then it will add statsrelay |#tags to every metric.

This feature should be very helpful with DataDog metrics management and any system supporting tags like InfluxDB backend for example. 
We can manage short key in metrics with dimensions defined in tags.