### PR TITLE
Add pprof support with HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Command synopsis:
     -packetlen="1400": Max packet length. Must be lower than MTU plus IPv4 and UDP headers to avoid fragmentation.
     -sendproto="UDP": IP Protocol for sending data - TCP or UDP
     -tcptimeout="1s": Timeout for TCP client remote connections
+    -pprof=false: Golang profiling support
+    -pprof-bind=":8080": Listen host:port for HTTP pprof data
     -verbose=false: Verbose output
 
 You must specify at least one HOST:PORT combination.  The INSTANCE can be

--- a/statsrelay.go
+++ b/statsrelay.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"strconv"
@@ -69,6 +71,12 @@ var bufferMaxSize int
 
 // Timeout value for remote TCP connection
 var TCPtimeout time.Duration
+
+// profiling bool value to enable disable http endpoint for profiling
+var profiling bool
+
+// profiling-bind string value for pprof http host:port data
+var profilingBind string
 
 // sockBufferMaxSize() returns the maximum size that the UDP receive buffer
 // in the kernel can be set to.  In bytes.
@@ -392,6 +400,9 @@ func main() {
 	flag.DurationVar(&TCPtimeout, "tcptimeout", 1*time.Second, "Timeout for TCP client remote connections")
 	flag.DurationVar(&TCPtimeout, "t", 1*time.Second, "Timeout for TCP client remote connections")
 
+	flag.BoolVar(&profiling, "pprof", false, "Enable HTTP endpoint for pprof")
+	flag.StringVar(&profilingBind, "pprof-bind", ":8080", "Bind for pprof HTTP endpoint")
+
 	defaultBufferSize, err := getSockBufferMaxSize()
 	if err != nil {
 		defaultBufferSize = 32 * 1024
@@ -403,6 +414,12 @@ func main() {
 
 	if len(flag.Args()) == 0 {
 		log.Fatalf("One or more host specifications are needed to locate statsd daemons.\n")
+	}
+
+	if profiling {
+		go func() {
+			log.Println(http.ListenAndServe(profilingBind, nil))
+		}()
 	}
 
 	for _, v := range flag.Args() {
@@ -440,4 +457,5 @@ func main() {
 	runServer(bindAddress, port)
 
 	log.Printf("Normal shutdown.\n")
+
 }

--- a/statsrelay.go
+++ b/statsrelay.go
@@ -75,7 +75,7 @@ var TCPtimeout time.Duration
 // profiling bool value to enable disable http endpoint for profiling
 var profiling bool
 
-// profiling-bind string value for pprof http host:port data
+// profilingBind string value for pprof http host:port data
 var profilingBind string
 
 // sockBufferMaxSize() returns the maximum size that the UDP receive buffer


### PR DESCRIPTION
Heap profile example:
```
go tool pprof http://localhost:8080/debug/pprof/heap
```
Or to look at a 30-second CPU profile example:
```
go tool pprof http://localhost:8080/debug/pprof/profile
```
Goroutine blocking profile example:
```
go tool pprof http://localhost:6060/debug/pprof/block
```

For longer profiling and saving Graphviz in png/svg/pdf:
```
go tool pprof http://localhost:8080/debug/pprof/profile?seconds=180
Fetching profile from http://localhost:8080/debug/pprof/profile?seconds=180
Please wait... (3m0s)
Saved profile in /tmp/pprof/pprof.statsrelay.localhost:8080.samples.cpu.007.pb.gz
Entering interactive mode (type "help" for commands)
(pprof) top
19890ms of 37300ms total (53.32%)
Dropped 343 nodes (cum <= 186.50ms)
Showing top 10 nodes out of 176 (cum >= 1860ms)
      flat  flat%   sum%        cum   cum%
    9880ms 26.49% 26.49%    10570ms 28.34%  syscall.Syscall
    3130ms  8.39% 34.88%     3130ms  8.39%  runtime.futex
    1320ms  3.54% 38.42%     2590ms  6.94%  runtime.mallocgc
    1180ms  3.16% 41.58%     1180ms  3.16%  syscall.RawSyscall
    1020ms  2.73% 44.32%     1020ms  2.73%  runtime._ExternalCode
    1020ms  2.73% 47.05%     1020ms  2.73%  runtime.epollctl
     970ms  2.60% 49.65%      970ms  2.60%  runtime.epollwait
     570ms  1.53% 51.18%      570ms  1.53%  runtime.heapBitsSetType
     430ms  1.15% 52.33%      430ms  1.15%  runtime.memmove
     370ms  0.99% 53.32%     1860ms  4.99%  runtime.newobject
(pprof) png > graph.png
Generating report in graph.png
(pprof) svg > graph.svg                                                                                                                                                                                                                      Generating report in graph.svg
```