### PR TITLE
tcp dial now takes less cpu. Some typo fix in log.

### DIFF
--- a/statsrelay.go
+++ b/statsrelay.go
@@ -249,13 +249,14 @@ func handleBuff(buff []byte) {
 		if err == nil {
 
 			target := hashRing.GetNode(metric).Server
+
 			if verbose {
 				log.Printf("Sending %s to %s", metric, target)
 			}
 
 			// check built packet size and send if metric doesn't fit
 			if packets[target].Len()+size > packetLen {
-				sendPacket(packets[target].Bytes(), target, sendproto, TCPtimeout)
+				go sendPacket(packets[target].Bytes(), target, sendproto, TCPtimeout)
 				packets[target].Reset()
 			}
 			// add to packet
@@ -304,7 +305,7 @@ func handleBuff(buff []byte) {
 	}
 
 	if verbose && time.Now().Unix()-epochTime > 0 {
-		log.Printf("Procssed %d metrics. Running total: %d. Metrics/sec: %d\n",
+		log.Printf("Processed %d metrics. Running total: %d. Metrics/sec: %d\n",
 			numMetrics, totalMetrics,
 			int64(totalMetrics)/(time.Now().Unix()-epochTime))
 	}


### PR DESCRIPTION
With bigger amount of metrics and TCP dial set statsrelay takes too much cpu, mainly because of open->send->close every packet. 
This need more rework, but for now there is super simple solution by backing whole send in go-routine.

This should work same with UDP dial.

Now how it is working in real world:
<img width="1658" alt="screen shot 2017-03-12 at 16 42 36" src="https://cloud.githubusercontent.com/assets/329831/23833296/a8d58de8-0743-11e7-9838-a834ab003b28.png">
As you can see there is huge CPU usage drop after this change.

And some stats from logs:
```
2017/03/12 08:03:14 Processed 5820 metrics. Running total: 759163. Metrics/sec: 4686
2017/03/12 08:03:15 Processed 6108 metrics. Running total: 765271. Metrics/sec: 4694
2017/03/12 08:03:16 Processed 8013 metrics. Running total: 773284. Metrics/sec: 4715
2017/03/12 08:03:17 Processed 6106 metrics. Running total: 779390. Metrics/sec: 4723
2017/03/12 08:03:18 Processed 6737 metrics. Running total: 786127. Metrics/sec: 4735
2017/03/12 08:03:19 Processed 8829 metrics. Running total: 794956. Metrics/sec: 4760
2017/03/12 08:03:21 Processed 8753 metrics. Running total: 803709. Metrics/sec: 4755
2017/03/12 08:03:23 Processed 15419 metrics. Running total: 819128. Metrics/sec: 4790
2017/03/12 08:03:26 Processed 15358 metrics. Running total: 834486. Metrics/sec: 4795
2017/03/12 08:03:26 Processed 14456 metrics. Running total: 848942. Metrics/sec: 4878
2017/03/12 08:03:27 Processed 12378 metrics. Running total: 861320. Metrics/sec: 4921
```

<img width="1664" alt="screen shot 2017-03-12 at 17 00 58" src="https://cloud.githubusercontent.com/assets/329831/23833427/95d1bf12-0745-11e7-92ed-0c341265ee88.png">

After changes cpu usage vs number of metrics per minute.