### PR TITLE
Bug with using `ctarget` variable

### DIFF
--- a/statsrelay.go
+++ b/statsrelay.go
@@ -365,7 +365,7 @@ func handleBuff(buff []byte) {
 	stats := fmt.Sprintf("%s:%d|c\n", statsMetric, numMetrics)
 	target := hashRing.GetNode(statsMetric).Server
 	if packets[target].Len()+len(stats) > packetLen {
-		sendPacket(packets[target].Bytes(), ctarget, sendproto, TCPtimeout, boff)
+		sendPacket(packets[target].Bytes(), target, sendproto, TCPtimeout, boff)
 		packets[target].Reset()
 	}
 	packets[target].Write([]byte(stats))


### PR DESCRIPTION
This prints messages to the log like:

```
2021/03/03 15:14:42 TCP error for  - dial tcp: missing address [Reconnecting in 50ms, retries left 3/3]
2021/03/03 15:14:42 TCP error for  - dial tcp: missing address [Reconnecting in 75ms, retries left 2/3]
2021/03/03 15:14:42 TCP error for  - dial tcp: missing address [Reconnecting in 112.5ms, retries left 1/3]
2021/03/03 15:14:55 TCP error for  - dial tcp: missing address [Reconnecting in 50ms, retries left 3/3]
2021/03/03 15:14:55 TCP error for  - dial tcp: missing address [Reconnecting in 75ms, retries left 2/3]
2021/03/03 15:14:55 TCP error for  - dial tcp: missing address [Reconnecting in 112.5ms, retries left 1/3]
```

because the `ctarget` variable is out of scope at this point.
Occasionally I see segfaults at this line.

Note:  This is using the default dnscache=false to see this