### PR TITLE
TCP Connection Pooling

### DIFF
--- a/statsrelay.go
+++ b/statsrelay.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/jpillora/backoff"
 	"io/ioutil"
 	"log"
 	"net"
@@ -20,9 +19,10 @@ import (
 	"syscall"
 	"time"
         "github.com/patrickmn/go-cache"
+  "github.com/dropbox/godropbox/net2"
 )
 
-const VERSION string = "0.0.9"
+const VERSION string = "0.0.10"
 
 // BUFFERSIZE controls the size of the [...]byte array used to read UDP data
 // off the wire and into local memory.  Metrics are separated by \n
@@ -52,6 +52,10 @@ var udpAddr = make(map[string]*net.UDPAddr)
 
 // tcpAddr is a mapping of HOST:PORT:INSTANCE to a TCPAddr object
 var tcpAddr = make(map[string]*net.TCPAddr)
+
+// tcpPool is our dropbox TCP connection pool object, representing
+// all statsd backend destinations
+var tcpPool net2.ConnectionPool
 
 // hashRing is our consistent hashing ring.
 var hashRing = NewJumpHashRing(1)
@@ -94,17 +98,21 @@ var profilingBind string
 // maxprocs int value to set GOMAXPROCS
 var maxprocs int
 
-// TCPMaxRetries int value for number of retries in dial tcp
-var TCPMaxRetries int
+// The maximum number of connections that can be active per host at any
+// given time (A non-positive value indicates the number of connections
+// is unbounded).
+var TCPMaxActive int
 
-// TCPMinBackoff duration value for minimal backoff limit time
-var TCPMinBackoff time.Duration
+// The maximum number of idle connections per host that are kept alive by
+// the connection pool.
+var TCPMaxIdle int
 
-// TCPMaxBackoff duration value for maximum backoff limit time
-var TCPMaxBackoff time.Duration
+// The maximum amount of time an idle connection can alive (if specified).
+var TCPMaxTimeout time.Duration
 
-// TCPFactorBackoff float64 value for backoff factor
-var TCPFactorBackoff float64
+// This limits the number of concurrent Dial calls (there's no limit when
+// DialMaxConcurrency is non-positive).
+var TCPMaxNewConnections int
 
 // dnscacheTime TTL of cached resolved k/v
 var dnscacheTime time.Duration
@@ -191,43 +199,50 @@ func genTags(metric, metricTags string) string {
 	return fmt.Sprintf("%s|#%s", metric, metricTags)
 }
 
+// write to the TCP connection pool, recovering errors and retrying
+func connectionPoolWrite(buff []byte, target string) {
+  // get an active connection from the pool
+  conn, err := tcpPool.Get("tcp", target)
+  if err != nil {
+    log.Printf("TCP Error in Pool.Get(): %s", err)
+    // Return on error to ignore this packet
+    return
+  }
+  _, err = conn.Write(buff)
+  if err != nil {
+    log.Printf("TCP Error writing to target pool %s: %s", target, err)
+    // Return on error to ignore this packet
+    return
+  }
+  // finished using the connection, release back to the pool 
+  conn.ReleaseConnection()
+}
+
 // sendPacket takes a []byte and writes that directly to a UDP socket
 // that was assigned for target.
-func sendPacket(buff []byte, target string, sendproto string, TCPtimeout time.Duration, boff *backoff.Backoff) {
-       switch sendproto {
-        case "UDP":
-		conn, err := net.ListenUDP("udp", nil)
-		if err != nil {
-			log.Panicln(err)
-		}
-		conn.WriteToUDP(buff, udpAddr[target])
-		conn.Close()
-        case "TCP":
-                if verbose {
-                   log.Printf("Sending to target: %s", target)
-                }
-		for i := 0; i < TCPMaxRetries; i++ {
-			conn, err := net.DialTimeout("tcp", target, TCPtimeout)
-			if err != nil {
-				doff := boff.Duration()
-				log.Printf("TCP error for %s - %s [Reconnecting in %s, retries left %d/%d]\n",
-					target, err, doff, TCPMaxRetries-i, TCPMaxRetries)
-				time.Sleep(doff)
-				continue
-			}
-			conn.Write(buff)
-			boff.Reset()
-			conn.Close()
-			break
-		}
-	case "TEST":
-		if verbose {
-			log.Printf("Debug: Would have sent packet of %d bytes to %s",
-				len(buff), target)
-		}
-	default:
-		log.Fatalf("Illegal send protocol %s", sendproto)
-	}
+func sendPacket(buff []byte, target string, sendproto string) {
+  switch sendproto {
+  case "UDP":
+    conn, err := net.ListenUDP("udp", nil)
+    if err != nil {
+      log.Panicln(err)
+    }
+    conn.WriteToUDP(buff, udpAddr[target])
+    conn.Close()
+  case "TCP":
+    if verbose {
+      log.Printf("Sending to target: %s => %s", target, buff)
+    }
+    connectionPoolWrite(buff, target)
+    break
+  case "TEST":
+    if verbose {
+      log.Printf("Debug: Would have sent packet of %d bytes to %s",
+      len(buff), target)
+    }
+  default:
+    log.Fatalf("Illegal send protocol %s", sendproto)
+  }
 }
 
 // buildPacketMap() is a helper function to initialize a map that represents
@@ -249,139 +264,140 @@ func buildPacketMap() map[string]*bytes.Buffer {
 // handleBuff() sorts through a full buffer of metrics and batches metrics
 // to remote statsd daemons using a consistent hash.
 func handleBuff(buff []byte) {
-	packets := buildPacketMap()
-	sep := []byte("\n")
-	numMetrics := 0
-	statsMetric := prefix + ".statsProcessed"
+  packets := buildPacketMap()
+  sep := []byte("\n")
+  numMetrics := 0
+  statsMetric := prefix + ".statsProcessed"
 
-	boff := &backoff.Backoff{
-		Min:    TCPMinBackoff,
-		Max:    TCPMaxBackoff,
-		Factor: TCPFactorBackoff,
-		Jitter: false,
-	}
+  for offset := 0; offset < len(buff); {
+    loop:
+    for offset < len(buff) {
+      // Find our next value
+      switch buff[offset] {
+      case '\n':
+        offset++
+      case '\r':
+        offset++
+      case 0:
+        offset++
+      default:
+        break loop
+      }
+    }
 
-	for offset := 0; offset < len(buff); {
-	loop:
-		for offset < len(buff) {
-			// Find our next value
-			switch buff[offset] {
-			case '\n':
-				offset++
-			case '\r':
-				offset++
-			case 0:
-				offset++
-			default:
-				break loop
-			}
-		}
+    size := bytes.IndexByte(buff[offset:], '\n')
+    if size == -1 {
+      // last metric in buffer
+      size = len(buff) - offset
+    }
+    if size == 0 {
+      // no more metrics
+      break
+    }
 
-		size := bytes.IndexByte(buff[offset:], '\n')
-		if size == -1 {
-			// last metric in buffer
-			size = len(buff) - offset
-		}
-		if size == 0 {
-			// no more metrics
-			break
-		}
+    // Check to ensure we get a metric, and not an invalid Byte sequence
+    metric, err := getMetricName(buff[offset : offset+size])
 
-		// Check to ensure we get a metric, and not an invalid Byte sequence
-		metric, err := getMetricName(buff[offset : offset+size])
+    if err == nil {
 
-		if err == nil {
+      target := hashRing.GetNode(metric).Server
+      ctarget := target
 
-                        target := hashRing.GetNode(metric).Server
-                        ctarget := target
+      // resolve and cache
+      if dnscache {
+        gettarget, found := c.Get(target)
+        if found {
+          ctarget = gettarget.(string)
+          if verbose {
+            log.Printf("Found in cache target %s (%s)", target, ctarget)
+          }
+        } else {
+          targetaddr, err := net.ResolveUDPAddr("udp", target)
+          if verbose {
+            log.Printf("Not found in cache adding target %s (%s)", target, ctarget)
+          }
+          if err != nil {
+            log.Printf("Error resolving target %s", target)
+          }
+          c.Set(target, targetaddr.String(), dnscacheExp)
+          ctarget = targetaddr.String()
+          // Register the destination IP:PORT combo in the TCP pool 
+          if sendproto == "TCP" {
+            tcpPool.Register("tcp", ctarget)
+          }
+        }
+      }
+      // check built packet size and send if metric doesn't fit
+      if packets[target].Len()+size > packetLen {
+        sendPacket(packets[target].Bytes(), ctarget, sendproto)
+        packets[target].Reset()
+      }
+      // add to packet
+      if len(metricsPrefix) != 0 || len(metricTags) != 0 {
+        buffPrefix, err := extendMetric(buff[offset:offset+size], metricsPrefix, metricTags)
+        if verbose {
+          log.Printf("Sending %s to %s (%s)", buffPrefix, target, ctarget)
+        }
+        if err != nil {
+          if len(metricsPrefix) != 0 {
+            log.Printf("Error %s when adding prefix %s", err, metricsPrefix)
+            break
+          }
+          if len(metricTags) != 0 {
+            log.Printf("Error %s when adding tag %s", err, metricTags)
+            break
+          }
+        }
+        packets[target].Write(buffPrefix)
+      } else {
+        if verbose {
+          log.Printf("Sending %s to %s (%s)", metric, target, ctarget)
+        }
+        packets[target].Write(buff[offset : offset+size])
+      }
+      packets[target].Write(sep)
+      numMetrics++
+    }
 
-                        // resolve and cache
-                        if dnscache {
-                                gettarget, found := c.Get(target)
-				if found {
-				   ctarget = gettarget.(string)
-				   if verbose {
-				      log.Printf("Found in cache target %s (%s)", target, ctarget)
-				   }
-				} else {
-                                   targetaddr, err := net.ResolveUDPAddr("udp", target)
-                                   if verbose {
-                                      log.Printf("Not found in cache adding target %s (%s)", target, ctarget)
-                                   }
-			           if err != nil {
-					   log.Printf("Error resolving target %s", target)
-				   }
-				   c.Set(target, targetaddr.String(), dnscacheExp)
-				   ctarget = targetaddr.String()
-				}
-                        }
-			// check built packet size and send if metric doesn't fit
-			if packets[target].Len()+size > packetLen {
-				sendPacket(packets[target].Bytes(), ctarget, sendproto, TCPtimeout, boff)
-				packets[target].Reset()
-			}
-			// add to packet
-			if len(metricsPrefix) != 0 || len(metricTags) != 0 {
-				buffPrefix, err := extendMetric(buff[offset:offset+size], metricsPrefix, metricTags)
-				if verbose {
-					log.Printf("Sending %s to %s (%s)", buffPrefix, target, ctarget)
-				}
-				if err != nil {
-					if len(metricsPrefix) != 0 {
-						log.Printf("Error %s when adding prefix %s", err, metricsPrefix)
-						break
-					}
-					if len(metricTags) != 0 {
-						log.Printf("Error %s when adding tag %s", err, metricTags)
-						break
-					}
-				}
-				packets[target].Write(buffPrefix)
-			} else {
-				if verbose {
-					log.Printf("Sending %s to %s (%s)", metric, target, ctarget)
-				}
-				packets[target].Write(buff[offset : offset+size])
-			}
-			packets[target].Write(sep)
-			numMetrics++
-		}
+    offset = offset + size + 1
+  }
 
-		offset = offset + size + 1
-	}
+  if numMetrics == 0 {
+    // if we haven't handled any metrics, then don't update counters/stats
+    // or send packets
+    return
+  }
 
-	if numMetrics == 0 {
-		// if we haven't handled any metrics, then don't update counters/stats
-		// or send packets
-		return
-	}
+  // Update internal counter
+  totalMetricsLock.Lock()
+  totalMetrics = totalMetrics + numMetrics
+  totalMetricsLock.Unlock()
 
-	// Update internal counter
-	totalMetricsLock.Lock()
-	totalMetrics = totalMetrics + numMetrics
-	totalMetricsLock.Unlock()
+  // Handle reporting our own stats
+  stats := fmt.Sprintf("%s:%d|c\n", statsMetric, numMetrics)
+  target := hashRing.GetNode(statsMetric).Server
+  if packets[target].Len()+len(stats) > packetLen {
+    sendPacket(packets[target].Bytes(), target, sendproto)
+    packets[target].Reset()
+  }
+  packets[target].Write([]byte(stats))
 
-	// Handle reporting our own stats
-	stats := fmt.Sprintf("%s:%d|c\n", statsMetric, numMetrics)
-	target := hashRing.GetNode(statsMetric).Server
-	if packets[target].Len()+len(stats) > packetLen {
-		sendPacket(packets[target].Bytes(), ctarget, sendproto, TCPtimeout, boff)
-		packets[target].Reset()
-	}
-	packets[target].Write([]byte(stats))
+  // Empty out any remaining data
+  for _, target := range hashRing.Nodes() {
+    if packets[target.Server].Len() > 0 {
+      sendPacket(packets[target.Server].Bytes(), target.Server, sendproto)
+    }
+  }
 
-	// Empty out any remaining data
-	for _, target := range hashRing.Nodes() {
-		if packets[target.Server].Len() > 0 {
-			sendPacket(packets[target.Server].Bytes(), target.Server, sendproto, TCPtimeout, boff)
-		}
-	}
-
-	if verbose && time.Now().Unix()-epochTime > 0 {
-		log.Printf("Processed %d metrics. Running total: %d. Metrics/sec: %d\n",
-			numMetrics, totalMetrics,
-			int64(totalMetrics)/(time.Now().Unix()-epochTime))
-	}
+  if verbose && time.Now().Unix()-epochTime > 0 {
+    log.Printf("Processed %d metrics. Running total: %d. Metrics/sec: %d\n",
+    numMetrics, totalMetrics,
+    int64(totalMetrics)/(time.Now().Unix()-epochTime))
+    if sendproto == "TCP" {
+      log.Printf("TCP Pool:  Active: %d   Max: %d  Idle: %d", 
+        tcpPool.NumActive(), tcpPool.ActiveHighWaterMark(), tcpPool.NumIdle())
+    }
+  }
 }
 
 // readUDP() a goroutine that just reads data off of a UDP socket and fills
@@ -418,7 +434,10 @@ func readUDP(ip string, port int, c chan []byte) {
 
 	if sendproto == "TCP" {
 		log.Printf("TCP send timeout set to %s", TCPtimeout)
-		log.Printf("TCP Backoff set Min: %s Max: %s Factor: %f Retries: %d", TCPMinBackoff, TCPMaxBackoff, TCPFactorBackoff, TCPMaxRetries)
+    log.Printf("TCP Pool maximum active connections: %d", TCPMaxActive)
+    log.Printf("TCP Pool maximum idle connections: %d", TCPMaxIdle)
+    log.Printf("TCP Pool maximum idle timeout: %v", TCPMaxTimeout)
+    log.Printf("TCP Pool maximum new concurrent connections: %d", TCPMaxNewConnections)
 	}
 
 	if len(metricsPrefix) != 0 {
@@ -490,6 +509,11 @@ func runServer(host string, port int) {
 	}
 }
 
+// wrapper function for connecting that we pass to the TCP pool
+func DialFunc(network string, address string) (net.Conn, error) {
+  return net.DialTimeout(network, address, TCPtimeout)
+}
+
 func main() {
 	var bindAddress string
 	var port int
@@ -524,11 +548,10 @@ func main() {
 	flag.BoolVar(&profiling, "pprof", false, "Enable HTTP endpoint for pprof")
 	flag.StringVar(&profilingBind, "pprof-bind", ":8080", "Bind for pprof HTTP endpoint")
 
-	flag.IntVar(&TCPMaxRetries, "backoff-retries", 3, "Maximum number of retries in backoff for TCP dial when sendproto set to TCP")
-	flag.DurationVar(&TCPMinBackoff, "backoff-min", 50*time.Millisecond, "Backoff minimal (integer) time in Millisecond")
-	flag.DurationVar(&TCPMaxBackoff, "backoff-max", 1000*time.Millisecond, "Backoff maximal (integer) time in Millisecond")
-	flag.Float64Var(&TCPFactorBackoff, "backoff-factor", 1.5, "Backoff factor (float)")
-
+  flag.IntVar(&TCPMaxActive, "tcpmaxactive", 500, "Maximum number of connections that can be active per host")
+  flag.IntVar(&TCPMaxIdle, "tcpmaxidle", 10, "Maximum number of idle connections per host that are kept alive")
+  flag.DurationVar(&TCPMaxTimeout, "tcpmaxtimeout", 5*time.Minute, "Maximum amount of time an idle connection can live")
+  flag.IntVar(&TCPMaxNewConnections, "tcpmaxnew", 100, "Maximum concurrent new connections created")
 
 	defaultBufferSize, err := getSockBufferMaxSize()
 	if err != nil {
@@ -553,6 +576,16 @@ func main() {
 			log.Println(http.ListenAndServe(profilingBind, nil))
 		}()
 	}
+
+  tcpPool = net2.NewMultiConnectionPool(net2.ConnectionOptions{
+    MaxActiveConnections: int32(TCPMaxActive),
+    MaxIdleConnections: uint32(TCPMaxIdle),
+    MaxIdleTime: &TCPMaxTimeout,
+    DialMaxConcurrency: TCPMaxNewConnections,
+    Dial: DialFunc,
+    ReadTimeout: TCPtimeout,
+    WriteTimeout: TCPtimeout,
+  })
 
 	for _, v := range flag.Args() {
 		var addr *net.UDPAddr
@@ -582,6 +615,10 @@ func main() {
 		if addr != nil {
 			udpAddr[v] = addr
 			hashRing.AddNode(Node{v, ""})
+      // Register the destination DNS:PORT combo in the TCP pool
+      if sendproto == "TCP" {
+        tcpPool.Register("tcp", v)
+      }
 		}
 	}
 

--- a/statsrelay.go
+++ b/statsrelay.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/jpillora/backoff"
 	"io/ioutil"
 	"log"
 	"net"
@@ -20,9 +19,10 @@ import (
 	"syscall"
 	"time"
         "github.com/patrickmn/go-cache"
+  "github.com/dropbox/godropbox/net2"
 )
 
-const VERSION string = "0.0.9"
+const VERSION string = "0.0.10"
 
 // BUFFERSIZE controls the size of the [...]byte array used to read UDP data
 // off the wire and into local memory.  Metrics are separated by \n
@@ -52,6 +52,10 @@ var udpAddr = make(map[string]*net.UDPAddr)
 
 // tcpAddr is a mapping of HOST:PORT:INSTANCE to a TCPAddr object
 var tcpAddr = make(map[string]*net.TCPAddr)
+
+// tcpPool is our dropbox TCP connection pool object, representing
+// all statsd backend destinations
+var tcpPool net2.ConnectionPool
 
 // hashRing is our consistent hashing ring.
 var hashRing = NewJumpHashRing(1)
@@ -94,17 +98,21 @@ var profilingBind string
 // maxprocs int value to set GOMAXPROCS
 var maxprocs int
 
-// TCPMaxRetries int value for number of retries in dial tcp
-var TCPMaxRetries int
+// The maximum number of connections that can be active per host at any
+// given time (A non-positive value indicates the number of connections
+// is unbounded).
+var TCPMaxActive int
 
-// TCPMinBackoff duration value for minimal backoff limit time
-var TCPMinBackoff time.Duration
+// The maximum number of idle connections per host that are kept alive by
+// the connection pool.
+var TCPMaxIdle int
 
-// TCPMaxBackoff duration value for maximum backoff limit time
-var TCPMaxBackoff time.Duration
+// The maximum amount of time an idle connection can alive (if specified).
+var TCPMaxTimeout time.Duration
 
-// TCPFactorBackoff float64 value for backoff factor
-var TCPFactorBackoff float64
+// This limits the number of concurrent Dial calls (there's no limit when
+// DialMaxConcurrency is non-positive).
+var TCPMaxNewConnections int
 
 // dnscacheTime TTL of cached resolved k/v
 var dnscacheTime time.Duration
@@ -191,43 +199,50 @@ func genTags(metric, metricTags string) string {
 	return fmt.Sprintf("%s|#%s", metric, metricTags)
 }
 
+// write to the TCP connection pool, recovering errors and retrying
+func connectionPoolWrite(buff []byte, target string) {
+  // get an active connection from the pool
+  conn, err := tcpPool.Get("tcp", target)
+  if err != nil {
+    log.Printf("TCP Error in Pool.Get(): %s", err)
+    // Return on error to ignore this packet
+    return
+  }
+  _, err = conn.Write(buff)
+  if err != nil {
+    log.Printf("TCP Error writing to target pool %s: %s", target, err)
+    // Return on error to ignore this packet
+    return
+  }
+  // finished using the connection, release back to the pool 
+  conn.ReleaseConnection()
+}
+
 // sendPacket takes a []byte and writes that directly to a UDP socket
 // that was assigned for target.
-func sendPacket(buff []byte, target string, sendproto string, TCPtimeout time.Duration, boff *backoff.Backoff) {
-       switch sendproto {
-        case "UDP":
-		conn, err := net.ListenUDP("udp", nil)
-		if err != nil {
-			log.Panicln(err)
-		}
-		conn.WriteToUDP(buff, udpAddr[target])
-		conn.Close()
-        case "TCP":
-                if verbose {
-                   log.Printf("Sending to target: %s", target)
-                }
-		for i := 0; i < TCPMaxRetries; i++ {
-			conn, err := net.DialTimeout("tcp", target, TCPtimeout)
-			if err != nil {
-				doff := boff.Duration()
-				log.Printf("TCP error for %s - %s [Reconnecting in %s, retries left %d/%d]\n",
-					target, err, doff, TCPMaxRetries-i, TCPMaxRetries)
-				time.Sleep(doff)
-				continue
-			}
-			conn.Write(buff)
-			boff.Reset()
-			conn.Close()
-			break
-		}
-	case "TEST":
-		if verbose {
-			log.Printf("Debug: Would have sent packet of %d bytes to %s",
-				len(buff), target)
-		}
-	default:
-		log.Fatalf("Illegal send protocol %s", sendproto)
-	}
+func sendPacket(buff []byte, target string, sendproto string) {
+  switch sendproto {
+  case "UDP":
+    conn, err := net.ListenUDP("udp", nil)
+    if err != nil {
+      log.Panicln(err)
+    }
+    conn.WriteToUDP(buff, udpAddr[target])
+    conn.Close()
+  case "TCP":
+    if verbose {
+      log.Printf("Sending to target: %s => %s", target, buff)
+    }
+    connectionPoolWrite(buff, target)
+    break
+  case "TEST":
+    if verbose {
+      log.Printf("Debug: Would have sent packet of %d bytes to %s",
+      len(buff), target)
+    }
+  default:
+    log.Fatalf("Illegal send protocol %s", sendproto)
+  }
 }
 
 // buildPacketMap() is a helper function to initialize a map that represents
@@ -249,139 +264,140 @@ func buildPacketMap() map[string]*bytes.Buffer {
 // handleBuff() sorts through a full buffer of metrics and batches metrics
 // to remote statsd daemons using a consistent hash.
 func handleBuff(buff []byte) {
-	packets := buildPacketMap()
-	sep := []byte("\n")
-	numMetrics := 0
-	statsMetric := prefix + ".statsProcessed"
+  packets := buildPacketMap()
+  sep := []byte("\n")
+  numMetrics := 0
+  statsMetric := prefix + ".statsProcessed"
 
-	boff := &backoff.Backoff{
-		Min:    TCPMinBackoff,
-		Max:    TCPMaxBackoff,
-		Factor: TCPFactorBackoff,
-		Jitter: false,
-	}
+  for offset := 0; offset < len(buff); {
+    loop:
+    for offset < len(buff) {
+      // Find our next value
+      switch buff[offset] {
+      case '\n':
+        offset++
+      case '\r':
+        offset++
+      case 0:
+        offset++
+      default:
+        break loop
+      }
+    }
 
-	for offset := 0; offset < len(buff); {
-	loop:
-		for offset < len(buff) {
-			// Find our next value
-			switch buff[offset] {
-			case '\n':
-				offset++
-			case '\r':
-				offset++
-			case 0:
-				offset++
-			default:
-				break loop
-			}
-		}
+    size := bytes.IndexByte(buff[offset:], '\n')
+    if size == -1 {
+      // last metric in buffer
+      size = len(buff) - offset
+    }
+    if size == 0 {
+      // no more metrics
+      break
+    }
 
-		size := bytes.IndexByte(buff[offset:], '\n')
-		if size == -1 {
-			// last metric in buffer
-			size = len(buff) - offset
-		}
-		if size == 0 {
-			// no more metrics
-			break
-		}
+    // Check to ensure we get a metric, and not an invalid Byte sequence
+    metric, err := getMetricName(buff[offset : offset+size])
 
-		// Check to ensure we get a metric, and not an invalid Byte sequence
-		metric, err := getMetricName(buff[offset : offset+size])
+    if err == nil {
 
-		if err == nil {
+      target := hashRing.GetNode(metric).Server
+      ctarget := target
 
-                        target := hashRing.GetNode(metric).Server
-                        ctarget := target
+      // resolve and cache
+      if dnscache {
+        gettarget, found := c.Get(target)
+        if found {
+          ctarget = gettarget.(string)
+          if verbose {
+            log.Printf("Found in cache target %s (%s)", target, ctarget)
+          }
+        } else {
+          targetaddr, err := net.ResolveUDPAddr("udp", target)
+          if verbose {
+            log.Printf("Not found in cache adding target %s (%s)", target, ctarget)
+          }
+          if err != nil {
+            log.Printf("Error resolving target %s", target)
+          }
+          c.Set(target, targetaddr.String(), dnscacheExp)
+          ctarget = targetaddr.String()
+          // Register the destination IP:PORT combo in the TCP pool 
+          if sendproto == "TCP" {
+            tcpPool.Register("tcp", ctarget)
+          }
+        }
+      }
+      // check built packet size and send if metric doesn't fit
+      if packets[target].Len()+size > packetLen {
+        sendPacket(packets[target].Bytes(), ctarget, sendproto)
+        packets[target].Reset()
+      }
+      // add to packet
+      if len(metricsPrefix) != 0 || len(metricTags) != 0 {
+        buffPrefix, err := extendMetric(buff[offset:offset+size], metricsPrefix, metricTags)
+        if verbose {
+          log.Printf("Sending %s to %s (%s)", buffPrefix, target, ctarget)
+        }
+        if err != nil {
+          if len(metricsPrefix) != 0 {
+            log.Printf("Error %s when adding prefix %s", err, metricsPrefix)
+            break
+          }
+          if len(metricTags) != 0 {
+            log.Printf("Error %s when adding tag %s", err, metricTags)
+            break
+          }
+        }
+        packets[target].Write(buffPrefix)
+      } else {
+        if verbose {
+          log.Printf("Sending %s to %s (%s)", metric, target, ctarget)
+        }
+        packets[target].Write(buff[offset : offset+size])
+      }
+      packets[target].Write(sep)
+      numMetrics++
+    }
 
-                        // resolve and cache
-                        if dnscache {
-                                gettarget, found := c.Get(target)
-				if found {
-				   ctarget = gettarget.(string)
-				   if verbose {
-				      log.Printf("Found in cache target %s (%s)", target, ctarget)
-				   }
-				} else {
-                                   targetaddr, err := net.ResolveUDPAddr("udp", target)
-                                   if verbose {
-                                      log.Printf("Not found in cache adding target %s (%s)", target, ctarget)
-                                   }
-			           if err != nil {
-					   log.Printf("Error resolving target %s", target)
-				   }
-				   c.Set(target, targetaddr.String(), dnscacheExp)
-				   ctarget = targetaddr.String()
-				}
-                        }
-			// check built packet size and send if metric doesn't fit
-			if packets[target].Len()+size > packetLen {
-				sendPacket(packets[target].Bytes(), ctarget, sendproto, TCPtimeout, boff)
-				packets[target].Reset()
-			}
-			// add to packet
-			if len(metricsPrefix) != 0 || len(metricTags) != 0 {
-				buffPrefix, err := extendMetric(buff[offset:offset+size], metricsPrefix, metricTags)
-				if verbose {
-					log.Printf("Sending %s to %s (%s)", buffPrefix, target, ctarget)
-				}
-				if err != nil {
-					if len(metricsPrefix) != 0 {
-						log.Printf("Error %s when adding prefix %s", err, metricsPrefix)
-						break
-					}
-					if len(metricTags) != 0 {
-						log.Printf("Error %s when adding tag %s", err, metricTags)
-						break
-					}
-				}
-				packets[target].Write(buffPrefix)
-			} else {
-				if verbose {
-					log.Printf("Sending %s to %s (%s)", metric, target, ctarget)
-				}
-				packets[target].Write(buff[offset : offset+size])
-			}
-			packets[target].Write(sep)
-			numMetrics++
-		}
+    offset = offset + size + 1
+  }
 
-		offset = offset + size + 1
-	}
+  if numMetrics == 0 {
+    // if we haven't handled any metrics, then don't update counters/stats
+    // or send packets
+    return
+  }
 
-	if numMetrics == 0 {
-		// if we haven't handled any metrics, then don't update counters/stats
-		// or send packets
-		return
-	}
+  // Update internal counter
+  totalMetricsLock.Lock()
+  totalMetrics = totalMetrics + numMetrics
+  totalMetricsLock.Unlock()
 
-	// Update internal counter
-	totalMetricsLock.Lock()
-	totalMetrics = totalMetrics + numMetrics
-	totalMetricsLock.Unlock()
+  // Handle reporting our own stats
+  stats := fmt.Sprintf("%s:%d|c\n", statsMetric, numMetrics)
+  target := hashRing.GetNode(statsMetric).Server
+  if packets[target].Len()+len(stats) > packetLen {
+    sendPacket(packets[target].Bytes(), target, sendproto)
+    packets[target].Reset()
+  }
+  packets[target].Write([]byte(stats))
 
-	// Handle reporting our own stats
-	stats := fmt.Sprintf("%s:%d|c\n", statsMetric, numMetrics)
-	target := hashRing.GetNode(statsMetric).Server
-	if packets[target].Len()+len(stats) > packetLen {
-		sendPacket(packets[target].Bytes(), target, sendproto, TCPtimeout, boff)
-		packets[target].Reset()
-	}
-	packets[target].Write([]byte(stats))
+  // Empty out any remaining data
+  for _, target := range hashRing.Nodes() {
+    if packets[target.Server].Len() > 0 {
+      sendPacket(packets[target.Server].Bytes(), target.Server, sendproto)
+    }
+  }
 
-	// Empty out any remaining data
-	for _, target := range hashRing.Nodes() {
-		if packets[target.Server].Len() > 0 {
-			sendPacket(packets[target.Server].Bytes(), target.Server, sendproto, TCPtimeout, boff)
-		}
-	}
-
-	if verbose && time.Now().Unix()-epochTime > 0 {
-		log.Printf("Processed %d metrics. Running total: %d. Metrics/sec: %d\n",
-			numMetrics, totalMetrics,
-			int64(totalMetrics)/(time.Now().Unix()-epochTime))
-	}
+  if verbose && time.Now().Unix()-epochTime > 0 {
+    log.Printf("Processed %d metrics. Running total: %d. Metrics/sec: %d\n",
+    numMetrics, totalMetrics,
+    int64(totalMetrics)/(time.Now().Unix()-epochTime))
+    if sendproto == "TCP" {
+      log.Printf("TCP Pool:  Active: %d   Max: %d  Idle: %d", 
+        tcpPool.NumActive(), tcpPool.ActiveHighWaterMark(), tcpPool.NumIdle())
+    }
+  }
 }
 
 // readUDP() a goroutine that just reads data off of a UDP socket and fills
@@ -418,7 +434,10 @@ func readUDP(ip string, port int, c chan []byte) {
 
 	if sendproto == "TCP" {
 		log.Printf("TCP send timeout set to %s", TCPtimeout)
-		log.Printf("TCP Backoff set Min: %s Max: %s Factor: %f Retries: %d", TCPMinBackoff, TCPMaxBackoff, TCPFactorBackoff, TCPMaxRetries)
+    log.Printf("TCP Pool maximum active connections: %d", TCPMaxActive)
+    log.Printf("TCP Pool maximum idle connections: %d", TCPMaxIdle)
+    log.Printf("TCP Pool maximum idle timeout: %v", TCPMaxTimeout)
+    log.Printf("TCP Pool maximum new concurrent connections: %d", TCPMaxNewConnections)
 	}
 
 	if len(metricsPrefix) != 0 {
@@ -490,6 +509,11 @@ func runServer(host string, port int) {
 	}
 }
 
+// wrapper function for connecting that we pass to the TCP pool
+func DialFunc(network string, address string) (net.Conn, error) {
+  return net.DialTimeout(network, address, TCPtimeout)
+}
+
 func main() {
 	var bindAddress string
 	var port int
@@ -524,11 +548,10 @@ func main() {
 	flag.BoolVar(&profiling, "pprof", false, "Enable HTTP endpoint for pprof")
 	flag.StringVar(&profilingBind, "pprof-bind", ":8080", "Bind for pprof HTTP endpoint")
 
-	flag.IntVar(&TCPMaxRetries, "backoff-retries", 3, "Maximum number of retries in backoff for TCP dial when sendproto set to TCP")
-	flag.DurationVar(&TCPMinBackoff, "backoff-min", 50*time.Millisecond, "Backoff minimal (integer) time in Millisecond")
-	flag.DurationVar(&TCPMaxBackoff, "backoff-max", 1000*time.Millisecond, "Backoff maximal (integer) time in Millisecond")
-	flag.Float64Var(&TCPFactorBackoff, "backoff-factor", 1.5, "Backoff factor (float)")
-
+  flag.IntVar(&TCPMaxActive, "tcpmaxactive", 500, "Maximum number of connections that can be active per host")
+  flag.IntVar(&TCPMaxIdle, "tcpmaxidle", 10, "Maximum number of idle connections per host that are kept alive")
+  flag.DurationVar(&TCPMaxTimeout, "tcpmaxtimeout", 5*time.Minute, "Maximum amount of time an idle connection can live")
+  flag.IntVar(&TCPMaxNewConnections, "tcpmaxnew", 100, "Maximum concurrent new connections created")
 
 	defaultBufferSize, err := getSockBufferMaxSize()
 	if err != nil {
@@ -553,6 +576,16 @@ func main() {
 			log.Println(http.ListenAndServe(profilingBind, nil))
 		}()
 	}
+
+  tcpPool = net2.NewMultiConnectionPool(net2.ConnectionOptions{
+    MaxActiveConnections: int32(TCPMaxActive),
+    MaxIdleConnections: uint32(TCPMaxIdle),
+    MaxIdleTime: &TCPMaxTimeout,
+    DialMaxConcurrency: TCPMaxNewConnections,
+    Dial: DialFunc,
+    ReadTimeout: TCPtimeout,
+    WriteTimeout: TCPtimeout,
+  })
 
 	for _, v := range flag.Args() {
 		var addr *net.UDPAddr
@@ -582,6 +615,10 @@ func main() {
 		if addr != nil {
 			udpAddr[v] = addr
 			hashRing.AddNode(Node{v, ""})
+      // Register the destination DNS:PORT combo in the TCP pool
+      if sendproto == "TCP" {
+        tcpPool.Register("tcp", v)
+      }
 		}
 	}
 

--- a/statsrelay.go
+++ b/statsrelay.go
@@ -365,7 +365,7 @@ func handleBuff(buff []byte) {
 	stats := fmt.Sprintf("%s:%d|c\n", statsMetric, numMetrics)
 	target := hashRing.GetNode(statsMetric).Server
 	if packets[target].Len()+len(stats) > packetLen {
-		sendPacket(packets[target].Bytes(), ctarget, sendproto, TCPtimeout, boff)
+		sendPacket(packets[target].Bytes(), target, sendproto, TCPtimeout, boff)
 		packets[target].Reset()
 	}
 	packets[target].Write([]byte(stats))


### PR DESCRIPTION
This is my first experience with Go, so let me know if I'm doing anything wrong here with style or implementation!

This PR adds Dropbox's net2 ConnectionPool library.  New command line flags for tuning the pool are:

```
  -tcpmaxactive int
        Maximum number of connections that can be active per host (default 500)
  -tcpmaxidle int
        Maximum number of idle connections per host that are kept alive (default 10)
  -tcpmaxnew int
        Maximum concurrent new connections created (default 100)
  -tcpmaxtimeout duration
        Maximum amount of time an idle connection can live (default 5m0s)
```

Speedup with connection pooling is approxy 10x faster in some isolated tests I ran.

My motivation for this was seeing some timeouts to the my backend statsd load balancers, running with TCP.  I only run around 200 stats per second through statsd from my client apps.  I use UDP from the client app to an AWS ALB, running two ECS containers for statsrelay.  I have two statsd backend instances, each with their own ALB load balancer exposed as TCP.

At a rate of around 2 or 3 per second, statsrelay would print error messages liike `dial tcp 10.10.12.245:8125: i/o timeout [Reconnecting in 50ms, retries left 3/3]`  The backend TCP ALBs were also showing a new flow rate of around 1,200 connections, and only an active flow count of around 5 - 10.  

So, I interpreted that as there must be a ton of overhead on the TCP connection setup/teardown.  Switching to UDP didn't help much, and I noticed that stats were being dropped and my numbers didn't quite compare the same with our Elasticsearch docs.

I found a nice connection pool library from Dropbox, and took a crack at implementing a connection pool.  Deploying this to production, the TCP Pool stats show one active connection, and two idle connections.  Here's a nice view on the drastic change in the load balancers:

![2021-03-05_13 27 06 666](https://user-images.githubusercontent.com/1163502/110165943-44b3fc00-7db9-11eb-9e45-2e18abc575fa.png)

The new flow count dropped to nothing, the active flow count settled out, and the throughput to the ALB went from around 32KB/s down to 5KB/s.  And because of that, the capacity units on the ALBs dropped as well.

One additional curiosity that I noticed with my pooling addition -- some of my metrics with your 0.0.9 version were reporting 3x the rate that they should be.  After deploying my connection pool code, the count for the number of metrics for this controller dropped, and now match the rate we see in our Elasticsearch system.

![2021-03-05_13 30 23 980](https://user-images.githubusercontent.com/1163502/110166807-7d080a00-7dba-11eb-999c-a6d838f3d467.png)

I have no idea what would cause this, other than the 3x rate seems to correlate with the number of retries on TCP connections.  In any event, it seems more accurate now!